### PR TITLE
완료 되지 않는 과제 수만큼 달력 표시

### DIFF
--- a/scripts/content-script.js
+++ b/scripts/content-script.js
@@ -153,6 +153,7 @@ async function loadCalendarDate({ year, month }) {
   const calendar = document.querySelectorAll('.calendar-content-week>li');
   for (let i = 0; i < calendar.length; i += 1) {
     calendar[i].innerHTML = '';
+    calendar[i].style.backgroundColor = 'var(--backgroundColor)';
   }
   for (let i = startDay; i < lastDay.getDate() + startDay; i += 1) {
     renderCell(calendar[i], i - startDay + 1);

--- a/scripts/content-script.js
+++ b/scripts/content-script.js
@@ -114,13 +114,17 @@ function renderCell(cell, date) {
     quizDiv.className = 'calendar-content-week-icon quiz';
   }
 
-  if (homeWork.length > 0) homeWorkDiv.innerText = `${homeWork.length}`;
+  if (homeWork.length > 0)
+    homeWorkDiv.innerText = `${homeWork.filter((item) => !item.isDone).length}`;
   else homeWorkDiv.style.visibility = 'hidden';
-  if (video.length > 0) videoDiv.innerText = `${video.length}`;
+  if (video.length > 0)
+    videoDiv.innerText = `${video.filter((item) => !item.isDone).length}`;
   else videoDiv.style.visibility = 'hidden';
-  if (zoom.length > 0) zoomDiv.innerText = `${zoom.length}`;
+  if (zoom.length > 0)
+    zoomDiv.innerText = `${zoom.filter((item) => !item.isDone).length}`;
   else zoomDiv.style.visibility = 'hidden';
-  if (quiz.length > 0) quizDiv.innerText = `${quiz.length}`;
+  if (quiz.length > 0)
+    quizDiv.innerText = `${quiz.filter((item) => !item.isDone).length}`;
   else quizDiv.style.visibility = 'hidden';
 
   homeWorkDiv.addEventListener('click', () => openModal(homeWork));


### PR DESCRIPTION
## 수정사항
- 달력에 `!isDone` 개수만큼 표시하기 
- 날자가 들어가지 않는 부분 배경화면 (조금) 어둡게 처리

## 참고 이미지
- 3개만 완료된 상태, 3개는 미완 상태
<span style="display:flex">
<img width="45%" alt="image" src="https://github.com/pnuniverse/plato-calendar-2/assets/96461334/3e2547a0-4174-4bd5-9c78-0383e4b96882">

<img width="45%" alt="image" src="https://github.com/pnuniverse/plato-calendar-2/assets/96461334/2cb24f6a-690e-4998-9d2a-a1f7d06a977d">
</span>

- 배경색 (조금) 어둡게 처리
<img width="50%" alt="image" src="https://github.com/pnuniverse/plato-calendar-2/assets/96461334/77b3bd4a-a591-4cd5-9f68-9ff99b5871cb">
